### PR TITLE
fix leading zero issue during encoding with tests

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -68,16 +68,8 @@ impl Message {
 }
 
 fn encode_msg(msg: &impl ProstMessage) -> Result<Vec<u8>> {
-    let mut buf = vec![0u8; msg.encoded_len()];
+    let mut buf = Vec::with_capacity(msg.encoded_len());
     msg.encode(&mut buf)?;
-
-    // TODO: Prost seems to pad some messages with leading zeros. I noticed this for the
-    // Open message. This removes the leading zeros. But why are they there in the first place?
-    let first_nonzero_char = (&buf).iter().position(|x| x != &0);
-    if let Some(nonzero) = first_nonzero_char {
-        buf = buf[nonzero..].to_vec();
-    }
-
     Ok(buf)
 }
 


### PR DESCRIPTION
The issue with the leading zeros comes from [pre filling the vec with zeros](https://github.com/Frando/hypercore-protocol-rs/blob/master/src/message.rs#L71).
The prost encoding uses `BufMut` which uses `extend_from_slice` to append! the buffer.

This is fixed by allocating only with `Vec::with_capacity(msg.encoded_len())`.

Also a test to validate the encoding+decoding roundtrips for each message is provided.